### PR TITLE
add L1 Fee hook

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -312,6 +312,15 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	st.gas -= gas
 
+	// <specular modification>
+	if st.evm.Config.SpecularEVMPreTransferHook != nil {
+		err = st.evm.Config.SpecularEVMPreTransferHook(st.msg.(types.Message), st.evm)
+		if err != nil {
+			return nil, err
+		}
+	}
+	// <specular modification/>
+
 	// Check clause 6
 	if msg.Value().Sign() > 0 && !st.evm.Context.CanTransfer(st.state, msg.From(), msg.Value()) {
 		return nil, fmt.Errorf("%w: address %v", ErrInsufficientFundsForTransfer, msg.From().Hex())

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -21,8 +21,17 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
+
+	// <specular modification>
+	"github.com/ethereum/go-ethereum/core/types"
+	// <specular modification/>
+
 	"github.com/ethereum/go-ethereum/log"
 )
+
+// <specular modification>
+type EVMHook func(msg types.Message, evm *EVM) error //
+// <specular modification/>
 
 // Config are the configuration options for the Interpreter
 type Config struct {
@@ -34,6 +43,10 @@ type Config struct {
 	JumpTable *JumpTable // EVM instruction table, automatically populated if unset
 
 	ExtraEips []int // Additional EIPS that are to be enabled
+
+	// <specular modification>
+	SpecularEVMPreTransferHook EVMHook
+	// <specular modification/>
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -21,11 +21,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
-
-	// <specular modification>
 	"github.com/ethereum/go-ethereum/core/types"
-	// <specular modification/>
-
 	"github.com/ethereum/go-ethereum/log"
 )
 


### PR DESCRIPTION
Core changes:

Adds `SpecularEVMPreTransferHook`, a hook that can be injected via the EVM config and will be executed before any transfer.