### PR TITLE
engine-api support

### DIFF
--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -21,6 +21,10 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient" gencodec:"required"`
 		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 		BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
+		// <specular modification>
+		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
+		NoTxPool              bool                `json:"noTxPool,omitempty" gencodec:"optional"`
+		// <specular modification/>
 	}
 	var enc PayloadAttributes
 	enc.Timestamp = hexutil.Uint64(p.Timestamp)
@@ -28,6 +32,15 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 	enc.SuggestedFeeRecipient = p.SuggestedFeeRecipient
 	enc.Withdrawals = p.Withdrawals
 	enc.BeaconRoot = p.BeaconRoot
+	// <specular modification>
+	if p.Transactions != nil {
+		enc.Transactions = make([]hexutil.Bytes, len(p.Transactions))
+		for k, v := range p.Transactions {
+			enc.Transactions[k] = v
+		}
+	}
+	enc.NoTxPool = p.NoTxPool
+	// <specular modification/>
 	return json.Marshal(&enc)
 }
 
@@ -39,6 +52,10 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		SuggestedFeeRecipient *common.Address     `json:"suggestedFeeRecipient" gencodec:"required"`
 		Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 		BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
+		// <specular modification>
+		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
+		NoTxPool              *bool               `json:"noTxPool,omitempty" gencodec:"optional"`
+		// <specular modification/>
 	}
 	var dec PayloadAttributes
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -62,5 +79,16 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 	if dec.BeaconRoot != nil {
 		p.BeaconRoot = dec.BeaconRoot
 	}
+	// <specular modification>
+	if dec.Transactions != nil {
+		p.Transactions = make([][]byte, len(dec.Transactions))
+		for k, v := range dec.Transactions {
+			p.Transactions[k] = v
+		}
+	}
+	if dec.NoTxPool != nil {
+		p.NoTxPool = *dec.NoTxPool
+	}
+	// <specular modification/>
 	return nil
 }

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -36,11 +36,21 @@ type PayloadAttributes struct {
 	SuggestedFeeRecipient common.Address      `json:"suggestedFeeRecipient" gencodec:"required"`
 	Withdrawals           []*types.Withdrawal `json:"withdrawals"`
 	BeaconRoot            *common.Hash        `json:"parentBeaconBlockRoot"`
+	// <specular modification>
+	// Transactions is a field for L2s: the transactions list is forced into the block
+	Transactions [][]byte `json:"transactions,omitempty"  gencodec:"optional"`
+	// NoTxPool is a field for L2s: if true, the no transactions are taken out of the tx-pool,
+	// only transactions from the above Transactions list will be included.
+	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
+	// <specular modification//>
 }
 
 // JSON type overrides for PayloadAttributes.
 type payloadAttributesMarshaling struct {
 	Timestamp hexutil.Uint64
+	// <specular modification>
+	Transactions []hexutil.Bytes
+	// <specular modification/>
 }
 
 //go:generate go run github.com/fjl/gencodec -type ExecutableData -field-override executableDataMarshaling -out gen_ed.go

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -143,6 +143,9 @@ var (
 		utils.GpoPercentileFlag,
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
+		// <specular modification>
+		utils.EnableL2EngineApiFlag,
+		// <specular modification/>
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabaseFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -949,6 +949,14 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value:    metrics.DefaultConfig.InfluxDBOrganization,
 		Category: flags.MetricsCategory,
 	}
+
+	// <specular modification/>
+	EnableL2EngineApiFlag = &cli.BoolFlag{
+		Name:     "enableL2EngineApi",
+		Usage:    "Enable L2 Engine API",
+		Category: flags.EthCategory,
+	}
+	// </specular modification/>
 )
 
 var (
@@ -1585,6 +1593,12 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	if ctx.IsSet(MinerNewPayloadTimeout.Name) {
 		cfg.NewPayloadTimeout = ctx.Duration(MinerNewPayloadTimeout.Name)
 	}
+	// <specular modification>
+	cfg.EnableL2EngineApi = ctx.Bool(EnableL2EngineApiFlag.Name)
+	if cfg.EnableL2EngineApi {
+		log.Info("L2 Engine API enabled")
+	}
+	// <specular modification/>
 }
 
 func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -18,6 +18,7 @@
 package miner
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"sync"
@@ -31,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -43,6 +45,13 @@ type Backend interface {
 	TxPool() *txpool.TxPool
 }
 
+// <specular modification>
+type BackendWithHistoricalState interface {
+	StateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (*state.StateDB, tracers.StateReleaseFunc, error)
+}
+
+// <specular modification/>
+
 // Config is the configuration parameters of mining.
 type Config struct {
 	Etherbase common.Address `toml:",omitempty"` // Public address for block mining rewards
@@ -53,6 +62,10 @@ type Config struct {
 	Recommit  time.Duration  // The time interval for miner to re-create mining work.
 
 	NewPayloadTimeout time.Duration // The maximum time allowance for creating a new payload
+
+	// <specular modification>
+	EnableL2EngineApi bool `toml:",omitempty"`
+	// <specular modification/>
 }
 
 // DefaultConfig contains default settings for miner.
@@ -244,3 +257,10 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 func (miner *Miner) BuildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	return miner.worker.buildPayload(args)
 }
+
+// <specular modification>
+func (miner *Miner) IsL2EngineApiEnabled() bool {
+	return miner.worker.config.EnableL2EngineApi
+}
+
+// <specular modification/>

--- a/miner/payload_building.go
+++ b/miner/payload_building.go
@@ -41,6 +41,10 @@ type BuildPayloadArgs struct {
 	Random       common.Hash       // The provided randomness value
 	Withdrawals  types.Withdrawals // The provided withdrawals
 	BeaconRoot   *common.Hash      // The provided beaconRoot (Cancun)
+	// <specular modification>
+	NoTxPool     bool                 // Specular addition: option to disable tx pool contents from being included
+	Transactions []*types.Transaction // Specular addition: txs forced into the block via engine API
+	// <specular modification/>
 }
 
 // Id computes an 8-byte identifier by hashing the components of the payload arguments.
@@ -55,6 +59,16 @@ func (args *BuildPayloadArgs) Id() engine.PayloadID {
 	if args.BeaconRoot != nil {
 		hasher.Write(args.BeaconRoot[:])
 	}
+	// <specular modification>
+	if args.NoTxPool || len(args.Transactions) > 0 { // extend if extra payload attributes are used
+		binary.Write(hasher, binary.BigEndian, args.NoTxPool)
+		binary.Write(hasher, binary.BigEndian, uint64(len(args.Transactions)))
+		for _, tx := range args.Transactions {
+			h := tx.Hash()
+			hasher.Write(h[:])
+		}
+	}
+	// <specular modification/>
 	var out engine.PayloadID
 	copy(out[:], hasher.Sum(nil)[:8])
 	return out
@@ -188,6 +202,9 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 		withdrawals: args.Withdrawals,
 		beaconRoot:  args.BeaconRoot,
 		noTxs:       true,
+		// <specular modification>
+		txs: args.Transactions,
+		// <specular modification/>
 	}
 	empty := w.getSealingBlock(emptyParams)
 	if empty.err != nil {
@@ -196,6 +213,14 @@ func (w *worker) buildPayload(args *BuildPayloadArgs) (*Payload, error) {
 
 	// Construct a payload object for return.
 	payload := newPayload(empty.block, args.Id())
+	// <specular modification>
+	if args.NoTxPool { // don't start the background payload updating job if there is no tx pool to pull from
+		// make sure to make it appear as full, otherwise it will wait indefinitely for payload building to complete.
+		payload.full = empty.block
+		payload.fullFees = empty.fees
+		return payload, nil
+	}
+	// <specular modification/>
 
 	// Spin up a routine for updating the payload in background. This strategy
 	// can maximum the revenue for including transactions with highest fee.


### PR DESCRIPTION
This PR adds support to specular-geth to support deterministic execution of transactions via the engine-api.

To support this we need to make a few changes to geth:

- extend [`PayloadAttributes`](https://github.com/ethereum/execution-apis/blob/769c53c94c4e487337ad0edea9ee0dce49c79bfa/src/engine/specification.md#PayloadAttributesV1) with `Transactions`, a list of transaction to force include in the block
- extend [`PayloadAttributes`](https://github.com/ethereum/execution-apis/blob/769c53c94c4e487337ad0edea9ee0dce49c79bfa/src/engine/specification.md#PayloadAttributesV1) with `NoTxPool`,  if true no transactions are taken out of the tx-pool, only transactions from the above `Transactions` list will be included. to validate existing blocks we will exclude transactions from the mempool, to sequence new blocks we will include transactions from the mempool.
- allow proposers to reorg their own chain


Specular changes differ from optimism/superchain engine-api spec, because we don't use deposit/system transactions:

https://op-geth.optimism.io/

https://github.com/ethereum-optimism/optimism/blob/develop/specs/exec-engine.md#engine-api