### PR TITLE
lower min recommit interval to enable faster blocktime

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -57,7 +57,9 @@ const (
 
 	// minRecommitInterval is the minimal time interval to recreate the sealing block with
 	// any newly arrived transactions.
-	minRecommitInterval = 1 * time.Second
+	// <specular modification>
+	minRecommitInterval = 100 * time.Millisecond
+	// <specular modification/>
 
 	// maxRecommitInterval is the maximum time interval to recreate the sealing block with
 	// any newly arrived transactions.

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -297,7 +297,11 @@ func testAdjustInterval(t *testing.T, chainConfig *params.ChainConfig, engine co
 			estimate = estimate*(1-intervalAdjustRatio) + intervalAdjustRatio*(min-intervalAdjustBias)
 			wantMinInterval, wantRecommitInterval = 3*time.Second, time.Duration(estimate)*time.Nanosecond
 		case 3:
-			wantMinInterval, wantRecommitInterval = time.Second, time.Second
+			// <specular modification>
+			// lower than upstream test, since enforced min recommit interval is lower
+			wantMinInterval, wantRecommitInterval = 500*time.Millisecond, 500*time.Millisecond
+			// <specular modification/>
+
 		}
 
 		// Check interval


### PR DESCRIPTION
This PR lowers the `minRecommitInterval` from 1s to 100ms, to support a lower bound on the min time between producing sealing blocks.

This change should allow a consensus client to produce faster blocks.

We should also configure our L2 execution client to start with a [lower commit interval](https://github.com/ethereum-optimism/optimism/blob/bc009effa8c47eebe5bdc539e8bde79d60d380ac/op-e2e/e2eutils/geth/geth.go#L89C4-L89C12) to take advantage of this change.