### PR TITLE
gasLimit

### DIFF
--- a/beacon/engine/gen_blockparams.go
+++ b/beacon/engine/gen_blockparams.go
@@ -24,6 +24,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		// <specular modification>
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              bool                `json:"noTxPool,omitempty" gencodec:"optional"`
+		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
 		// <specular modification/>
 	}
 	var enc PayloadAttributes
@@ -40,6 +41,7 @@ func (p PayloadAttributes) MarshalJSON() ([]byte, error) {
 		}
 	}
 	enc.NoTxPool = p.NoTxPool
+	enc.GasLimit = (*hexutil.Uint64)(p.GasLimit)
 	// <specular modification/>
 	return json.Marshal(&enc)
 }
@@ -55,6 +57,7 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 		// <specular modification>
 		Transactions          []hexutil.Bytes     `json:"transactions,omitempty"  gencodec:"optional"`
 		NoTxPool              *bool               `json:"noTxPool,omitempty" gencodec:"optional"`
+		GasLimit              *hexutil.Uint64     `json:"gasLimit,omitempty" gencodec:"optional"`
 		// <specular modification/>
 	}
 	var dec PayloadAttributes
@@ -88,6 +91,9 @@ func (p *PayloadAttributes) UnmarshalJSON(input []byte) error {
 	}
 	if dec.NoTxPool != nil {
 		p.NoTxPool = *dec.NoTxPool
+	}
+	if dec.GasLimit != nil {
+		p.GasLimit = (*uint64)(dec.GasLimit)
 	}
 	// <specular modification/>
 	return nil

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -42,6 +42,8 @@ type PayloadAttributes struct {
 	// NoTxPool is a field for L2s: if true, the no transactions are taken out of the tx-pool,
 	// only transactions from the above Transactions list will be included.
 	NoTxPool bool `json:"noTxPool,omitempty" gencodec:"optional"`
+	// GasLimit is a field for L2s: if set, this sets the exact gas limit the block produced with.
+	GasLimit *uint64 `json:"gasLimit,omitempty" gencodec:"optional"`
 	// <specular modification//>
 }
 
@@ -50,6 +52,7 @@ type payloadAttributesMarshaling struct {
 	Timestamp hexutil.Uint64
 	// <specular modification>
 	Transactions []hexutil.Bytes
+	GasLimit     *hexutil.Uint64
 	// <specular modification/>
 }
 

--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -37,9 +37,15 @@ func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Heade
 	if !config.IsLondon(parent.Number) {
 		parentGasLimit = parent.GasLimit * config.ElasticityMultiplier()
 	}
-	if err := misc.VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
-		return err
+
+	// <specular modification>
+	if !config.EnableL2GasLimitApi { // gasLimit can adjust instantly on L2s
+		if err := misc.VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
+			return err
+		}
 	}
+	// <specular modification>
+
 	// Verify the header is not malformed
 	if header.BaseFee == nil {
 		return errors.New("header is missing baseFee")

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -367,6 +367,9 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 	// will replace it arbitrarily many times in between.
 	if payloadAttributes != nil {
 		// <specular modification>
+		if api.eth.BlockChain().Config().EnableL2GasLimitApi && payloadAttributes.GasLimit == nil {
+			return engine.STATUS_INVALID, engine.InvalidPayloadAttributes.With(errors.New("gasLimit parameter is required"))
+		}
 		transactions := make(types.Transactions, 0, len(payloadAttributes.Transactions))
 		for i, otx := range payloadAttributes.Transactions {
 			var tx types.Transaction
@@ -387,6 +390,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 			// <specular modification>
 			NoTxPool:     payloadAttributes.NoTxPool,
 			Transactions: transactions,
+			GasLimit:     payloadAttributes.GasLimit,
 			// <specular modification/>
 		}
 		id := args.Id()

--- a/params/config.go
+++ b/params/config.go
@@ -333,6 +333,10 @@ type ChainConfig struct {
 	Ethash    *EthashConfig `json:"ethash,omitempty"`
 	Clique    *CliqueConfig `json:"clique,omitempty"`
 	IsDevMode bool          `json:"isDev,omitempty"`
+
+	// <specular modification>
+	EnableL2GasLimitApi bool `json:"enableL2GasLimitApi,omitempty"`
+	// <specular modification/>
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
@@ -365,6 +369,10 @@ func (c *ChainConfig) Description() string {
 	}
 	banner += fmt.Sprintf("Chain ID:  %v (%s)\n", c.ChainID, network)
 	switch {
+	// <specular modification>
+	case c.EnableL2GasLimitApi:
+		banner += "Consensus: L2 gas limit API enabled\n"
+	// <specular modification/>
 	case c.Ethash != nil:
 		if c.TerminalTotalDifficulty == nil {
 			banner += "Consensus: Ethash (proof-of-work)\n"


### PR DESCRIPTION
Initial draft for add a `gasLimit` param to engine-api. This change will allow the consensus client, to specify a `gasLimit` for a block.

This PR change to consensus, to allow the `gasLimit` to change any amount between blocks, since EIP1559 limits the `gasLimit` delta between blocks.

The `EnableL2GasLimitApi ` consensus changes are configured via `ChainConfig`/`genesis.json` (persisted per-block in the chaindb) rather than with the `enableL2EngineAPI` flag. Otherwise we could run into consensus issues if we disable the `enableL2EngineAPI` flag and try to verify an L2 which had the `gasLimit` change between blocks >EIP1559 elasticity.

We could get around this, by hardcoding the consensus change, but then specular-geth will have relaxed consensus rules for verifying an L1.