### PR TITLE
Support base fee vault

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -387,6 +387,11 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindToBlock != 0) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
 		return newcfg, stored, compatErr
 	}
+	// <specular modification>
+	if (newcfg.IsLondon(head.Number) && newcfg.L2BaseFeeRecipient == common.Address{}) {
+		return newcfg, stored, errors.New("l2BaseFeeRecipient must be configured if EIP-1559 enabled")
+	}
+	// </specular modification>
 	// Don't overwrite if the old is identical to the new
 	if newData, _ := json.Marshal(newcfg); !bytes.Equal(storedData, newData) {
 		rawdb.WriteChainConfig(db, stored, newcfg)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -387,11 +387,6 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 	if compatErr != nil && ((head.Number.Uint64() != 0 && compatErr.RewindToBlock != 0) || (head.Time != 0 && compatErr.RewindToTime != 0)) {
 		return newcfg, stored, compatErr
 	}
-	// <specular modification>
-	if (newcfg.IsLondon(head.Number) && newcfg.L2BaseFeeRecipient == common.Address{}) {
-		return newcfg, stored, errors.New("l2BaseFeeRecipient must be configured if EIP-1559 enabled")
-	}
-	// </specular modification>
 	// Don't overwrite if the old is identical to the new
 	if newData, _ := json.Marshal(newcfg); !bytes.Equal(storedData, newData) {
 		rawdb.WriteChainConfig(db, stored, newcfg)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -506,6 +506,12 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
 	}
 
+	// <specular modification>
+	if (st.evm.ChainConfig().L2BaseFeeRecipient != common.Address{}) {
+		st.state.AddBalance(st.evm.ChainConfig().L2BaseFeeRecipient, new(big.Int).Mul(new(big.Int).SetUint64(st.gasUsed()), st.evm.Context.BaseFee))
+	}
+	// </specular modification>
+
 	return &ExecutionResult{
 		UsedGas:    st.gasUsed(),
 		Err:        vmerr,

--- a/params/config.go
+++ b/params/config.go
@@ -335,7 +335,8 @@ type ChainConfig struct {
 	IsDevMode bool          `json:"isDev,omitempty"`
 
 	// <specular modification>
-	EnableL2EngineApi bool `json:"enableL2EngineApi,omitempty"`
+	EnableL2EngineApi  bool           `json:"enableL2EngineApi,omitempty"`
+	L2BaseFeeRecipient common.Address `json:"l2BaseFeeRecipient,omitempty"`
 	// <specular modification/>
 }
 
@@ -372,6 +373,7 @@ func (c *ChainConfig) Description() string {
 	// <specular modification>
 	case c.EnableL2EngineApi:
 		banner += "Consensus: L2 gas limit API enabled\n"
+		banner += fmt.Sprintf(" - L2 Base fee recipient: %s\n", c.L2BaseFeeRecipient)
 	// <specular modification/>
 	case c.Ethash != nil:
 		if c.TerminalTotalDifficulty == nil {


### PR DESCRIPTION
Deposit EIP-1559 fees into the configured `L2BaseFeeRecipient`. This is a consensus change, so I configured the address in the chain config. Optimism [hardcodes ](https://github.com/ethereum-optimism/op-geth/blob/cf19c1e39c326a806df1096c45e3f2fbcd5ca00c/params/protocol_params.go#L27)the address, but I think my solution using chain config is more general.

Corresponding PR in specular: https://github.com/SpecularL2/specular/pull/239