### PR TITLE
Consolidate L2 engine api flag with L2 gas limit api

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -144,9 +144,6 @@ var (
 		utils.GpoPercentileFlag,
 		utils.GpoMaxGasPriceFlag,
 		utils.GpoIgnoreGasPriceFlag,
-		// <specular modification>
-		utils.EnableL2EngineApiFlag,
-		// <specular modification/>
 		configFileFlag,
 	}, utils.NetworkFlags, utils.DatabasePathFlags)
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -949,14 +949,6 @@ Please note that --` + MetricsHTTPFlag.Name + ` must be set to start the server.
 		Value:    metrics.DefaultConfig.InfluxDBOrganization,
 		Category: flags.MetricsCategory,
 	}
-
-	// <specular modification/>
-	EnableL2EngineApiFlag = &cli.BoolFlag{
-		Name:     "enableL2EngineApi",
-		Usage:    "Enable L2 Engine API",
-		Category: flags.EthCategory,
-	}
-	// </specular modification/>
 )
 
 var (
@@ -1582,12 +1574,6 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	if ctx.IsSet(MinerNewPayloadTimeout.Name) {
 		cfg.NewPayloadTimeout = ctx.Duration(MinerNewPayloadTimeout.Name)
 	}
-	// <specular modification>
-	cfg.EnableL2EngineApi = ctx.Bool(EnableL2EngineApiFlag.Name)
-	if cfg.EnableL2EngineApi {
-		log.Info("L2 Engine API enabled")
-	}
-	// <specular modification/>
 }
 
 func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {

--- a/consensus/misc/eip1559/eip1559.go
+++ b/consensus/misc/eip1559/eip1559.go
@@ -39,7 +39,7 @@ func VerifyEIP1559Header(config *params.ChainConfig, parent, header *types.Heade
 	}
 
 	// <specular modification>
-	if !config.EnableL2GasLimitApi { // gasLimit can adjust instantly on L2s
+	if !config.EnableL2EngineApi { // gasLimit can adjust instantly on L2s
 		if err := misc.VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
 			return err
 		}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -321,7 +321,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 		// generating the payload. It's a special corner case that a few slots are
 		// missing and we are requested to generate the payload in slot.
 		// <specular modification>
-	} else if !api.eth.BlockChain().Config().EnableL2GasLimitApi { // minor Engine API divergence: allow proposers to reorg their own chain
+	} else if !api.eth.BlockChain().Config().EnableL2EngineApi { // minor Engine API divergence: allow proposers to reorg their own chain
 		// <specular modification/>
 		// If the head block is already in our canonical chain, the beacon client is
 		// probably resyncing. Ignore the update.
@@ -367,7 +367,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 	// will replace it arbitrarily many times in between.
 	if payloadAttributes != nil {
 		// <specular modification>
-		if api.eth.BlockChain().Config().EnableL2GasLimitApi && payloadAttributes.GasLimit == nil {
+		if api.eth.BlockChain().Config().EnableL2EngineApi && payloadAttributes.GasLimit == nil {
 			return engine.STATUS_INVALID, engine.InvalidPayloadAttributes.With(errors.New("gasLimit parameter is required"))
 		}
 		transactions := make(types.Transactions, 0, len(payloadAttributes.Transactions))
@@ -738,7 +738,7 @@ func (api *ConsensusAPI) invalid(err error, latestValid *types.Header) engine.Pa
 // TODO(karalabe): Spin this goroutine down somehow
 func (api *ConsensusAPI) heartbeat() {
 	// <specular modification>
-	if api.eth.BlockChain().Config().EnableL2GasLimitApi { // don't start the api heartbeat, there is no transition
+	if api.eth.BlockChain().Config().EnableL2EngineApi { // don't start the api heartbeat, there is no transition
 		return
 	}
 	// <specular modification/>

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -321,7 +321,7 @@ func (api *ConsensusAPI) forkchoiceUpdated(update engine.ForkchoiceStateV1, payl
 		// generating the payload. It's a special corner case that a few slots are
 		// missing and we are requested to generate the payload in slot.
 		// <specular modification>
-	} else if !api.eth.Miner().IsL2EngineApiEnabled() { // minor Engine API divergence: allow proposers to reorg their own chain
+	} else if !api.eth.BlockChain().Config().EnableL2GasLimitApi { // minor Engine API divergence: allow proposers to reorg their own chain
 		// <specular modification/>
 		// If the head block is already in our canonical chain, the beacon client is
 		// probably resyncing. Ignore the update.
@@ -738,7 +738,7 @@ func (api *ConsensusAPI) invalid(err error, latestValid *types.Header) engine.Pa
 // TODO(karalabe): Spin this goroutine down somehow
 func (api *ConsensusAPI) heartbeat() {
 	// <specular modification>
-	if api.eth.Miner().IsL2EngineApiEnabled() { // don't start the api heartbeat, there is no transition
+	if api.eth.BlockChain().Config().EnableL2GasLimitApi { // don't start the api heartbeat, there is no transition
 		return
 	}
 	// <specular modification/>

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -62,10 +62,6 @@ type Config struct {
 	Recommit  time.Duration  // The time interval for miner to re-create mining work.
 
 	NewPayloadTimeout time.Duration // The maximum time allowance for creating a new payload
-
-	// <specular modification>
-	EnableL2EngineApi bool `toml:",omitempty"`
-	// <specular modification/>
 }
 
 // DefaultConfig contains default settings for miner.
@@ -257,10 +253,3 @@ func (miner *Miner) SubscribePendingLogs(ch chan<- []*types.Log) event.Subscript
 func (miner *Miner) BuildPayload(args *BuildPayloadArgs) (*Payload, error) {
 	return miner.worker.buildPayload(args)
 }
-
-// <specular modification>
-func (miner *Miner) IsL2EngineApiEnabled() bool {
-	return miner.worker.config.EnableL2EngineApi
-}
-
-// <specular modification/>

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -710,7 +710,7 @@ func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase co
 	// the miner to speed block sealing up a bit.
 	state, err := w.chain.StateAt(parent.Root)
 	// <specular modification>
-	if w.chainConfig.EnableL2GasLimitApi { // Allow the miner to reorg its own chain arbitrarily deep
+	if w.chainConfig.EnableL2EngineApi { // Allow the miner to reorg its own chain arbitrarily deep
 		if historicalBackend, ok := w.eth.(BackendWithHistoricalState); ok {
 			var release tracers.StateReleaseFunc
 			parentBlock := w.eth.BlockChain().GetBlockByHash(parent.Hash())
@@ -942,7 +942,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	}
 	// Set the extra field.
 	// <specular modification>
-	if len(w.extra) != 0 && !w.chainConfig.EnableL2GasLimitApi { // L2 chains must not set any extra data.
+	if len(w.extra) != 0 && !w.chainConfig.EnableL2EngineApi { // L2 chains must not set any extra data.
 		header.Extra = w.extra
 	}
 	// <specular modification/>
@@ -962,7 +962,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	// <specular modification>
 	if genParams.gasLimit != nil { // override gas limit if specified
 		header.GasLimit = *genParams.gasLimit
-	} else if w.chain.Config().EnableL2GasLimitApi && w.config.GasCeil != 0 {
+	} else if w.chain.Config().EnableL2EngineApi && w.config.GasCeil != 0 {
 		// configure the gas limit of pending blocks with the miner gas limit config when L2 gas limit config is enabled
 		header.GasLimit = w.config.GasCeil
 	}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -710,7 +710,7 @@ func (w *worker) makeEnv(parent *types.Header, header *types.Header, coinbase co
 	// the miner to speed block sealing up a bit.
 	state, err := w.chain.StateAt(parent.Root)
 	// <specular modification>
-	if w.config.EnableL2EngineApi { // Allow the miner to reorg its own chain arbitrarily deep
+	if w.chainConfig.EnableL2GasLimitApi { // Allow the miner to reorg its own chain arbitrarily deep
 		if historicalBackend, ok := w.eth.(BackendWithHistoricalState); ok {
 			var release tracers.StateReleaseFunc
 			parentBlock := w.eth.BlockChain().GetBlockByHash(parent.Hash())
@@ -942,7 +942,7 @@ func (w *worker) prepareWork(genParams *generateParams) (*environment, error) {
 	}
 	// Set the extra field.
 	// <specular modification>
-	if len(w.extra) != 0 && !w.config.EnableL2EngineApi { // L2 chains must not set any extra data.
+	if len(w.extra) != 0 && !w.chainConfig.EnableL2GasLimitApi { // L2 chains must not set any extra data.
 		header.Extra = w.extra
 	}
 	// <specular modification/>

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -301,7 +301,6 @@ func testAdjustInterval(t *testing.T, chainConfig *params.ChainConfig, engine co
 			// lower than upstream test, since enforced min recommit interval is lower
 			wantMinInterval, wantRecommitInterval = 500*time.Millisecond, 500*time.Millisecond
 			// <specular modification/>
-
 		}
 
 		// Check interval

--- a/params/config.go
+++ b/params/config.go
@@ -335,7 +335,7 @@ type ChainConfig struct {
 	IsDevMode bool          `json:"isDev,omitempty"`
 
 	// <specular modification>
-	EnableL2GasLimitApi bool `json:"enableL2GasLimitApi,omitempty"`
+	EnableL2EngineApi bool `json:"enableL2EngineApi,omitempty"`
 	// <specular modification/>
 }
 
@@ -370,7 +370,7 @@ func (c *ChainConfig) Description() string {
 	banner += fmt.Sprintf("Chain ID:  %v (%s)\n", c.ChainID, network)
 	switch {
 	// <specular modification>
-	case c.EnableL2GasLimitApi:
+	case c.EnableL2EngineApi:
 		banner += "Consensus: L2 gas limit API enabled\n"
 	// <specular modification/>
 	case c.Ethash != nil:


### PR DESCRIPTION
# Core changes

- Remove `EnableL2EngineApiFlag` and replace its functionality with `L2GasLimitApi` in chain config